### PR TITLE
fix(ai-researcher): Step.updates type

### DIFF
--- a/ai-researcher/agent/ai_researcher/state.py
+++ b/ai-researcher/agent/ai_researcher/state.py
@@ -17,7 +17,7 @@ class Step(TypedDict):
     description: str
     search_result: Optional[str]
     result: Optional[str]
-    updates: Optional[any]
+    updates: Optional[List[str]]
 
 class AgentState(MessagesState):
     """


### PR DESCRIPTION
This PR changes the type of `Step.updates` from `Optional[any]` to `Optional[List[str]]`.

* LangGraph Studio possibly uses an older Pydantic version which does not support `any`, which resulted in errors.
* This removes `any`, and in general it's better to be more explicit about the types.